### PR TITLE
Add example of how to customise providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ const firebaseAppAuth = firebaseApp.auth();
 const providers = {
   googleProvider: new firebase.auth.GoogleAuthProvider(),
 };
+/** providers can be customised as per the Firebase documentation on auth providers **/
+providers.googleProvider.setCustomParameters({hd:"mycompany.com"});
 
 /** Wrap it */
 export default withFirebaseAuth({


### PR DESCRIPTION
I needed to limit sign in to a particular google apps domain, which was easy but not obvious from this documentation