### PR TITLE
feat: 🎸 include signInWithApple provider

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -42,6 +42,7 @@ const App: React.FC<WrappedComponentProps> = ({
   signInWithEmailAndPassword,
   signInWithGoogle,
   signInWithGithub,
+  signInWithApple,
   createUserWithEmailAndPassword,
 }) => (
   <React.Fragment>
@@ -66,6 +67,11 @@ const App: React.FC<WrappedComponentProps> = ({
     <FormWrapper>
       <h1>sign in with google</h1>
       <button onClick={signInWithGoogle}>sign in with google</button>
+    </FormWrapper>
+
+    <FormWrapper>
+      <h1>sign in with apple</h1>
+      <button onClick={signInWithApple}>sign in with apple</button>
     </FormWrapper>
 
     <FormWrapper>
@@ -109,6 +115,7 @@ const firebaseAppAuth = firebaseApp.auth();
 
 const providers = {
   googleProvider: new firebase.auth.GoogleAuthProvider(),
+  appleProvider: new firebase.auth.OAuthProvider('apple.com'),
 };
 
 export default withFirebaseAuth({

--- a/src/getErrorMessageForProvider.ts
+++ b/src/getErrorMessageForProvider.ts
@@ -5,6 +5,7 @@ const providerToTypeMapper = {
   facebookProvider: 'firebase.auth.FacebookAuthProvider' as const,
   twitterProvider: 'firebase.auth.TwitterAuthProvider' as const,
   githubProvider: 'firebase.auth.GithubAuthProvider' as const,
+  appleProvider: 'firebase.auth.OAuthProvider' as const,
 };
 
 const providerToFirebaseDocs = {
@@ -16,6 +17,7 @@ const providerToFirebaseDocs = {
     'https://firebase.google.com/docs/auth/web/twitter-signin' as const,
   githubProvider:
     'https://firebase.google.com/docs/auth/web/github-auth' as const,
+  appleProvider: 'https://firebase.google.com/docs/auth/web/apple' as const,
 };
 
 const getErrorMessageForProvider = (provider: PossibleProviders) =>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ export type WrappedComponentProps = {
   signInWithFacebook: () => void;
   signInWithGithub: () => void;
   signInWithTwitter: () => void;
+  signInWithApple: () => void;
   signInWithPhoneNumber: (
     phoneNumber: string,
     applicationVerifier: firebase.auth.ApplicationVerifier
@@ -29,6 +30,7 @@ export type ProvidersMapper = {
   facebookProvider?: firebase.auth.FacebookAuthProvider_Instance;
   twitterProvider?: firebase.auth.TwitterAuthProvider_Instance;
   githubProvider?: firebase.auth.GithubAuthProvider_Instance;
+  appleProvider?: firebase.auth.OAuthProvider;
 };
 
 export type HocParameters = {
@@ -126,6 +128,8 @@ const withFirebaseAuth = ({
       signInWithFacebook = () =>
         this.tryToSignInWithProvider('facebookProvider');
 
+      signInWithApple = () => this.tryToSignInWithProvider('appleProvider');
+
       signInWithEmailAndPassword = (email: string, password: string) => {
         return this.tryTo<firebase.auth.UserCredential>(() =>
           firebaseAppAuth.signInWithEmailAndPassword(email, password)
@@ -157,6 +161,7 @@ const withFirebaseAuth = ({
         signInWithTwitter: this.signInWithTwitter,
         signInWithGoogle: this.signInWithGoogle,
         signInWithFacebook: this.signInWithFacebook,
+        signInWithApple: this.signInWithApple,
         signInWithPhoneNumber: this.signInWithPhoneNumber,
         signInAnonymously: this.signInAnonymously,
         setError: this.setError,

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -11,6 +11,7 @@ const providers = {
   twitterProvider: {} as firebase.auth.TwitterAuthProvider_Instance,
   githubProvider: {} as firebase.auth.GithubAuthProvider_Instance,
   facebookProvider: {} as firebase.auth.FacebookAuthProvider_Instance,
+  appleProvider: {} as firebase.auth.OAuthProvider,
 };
 
 const fakeUser = {
@@ -211,6 +212,25 @@ describe('withFirebaseAuth', () => {
       signInWithFacebook,
     }: WrappedComponentProps) => (
       <button onClick={() => signInWithFacebook()}>signInWithFacebook</button>
+    );
+
+    const EnhancedComponent = withFirebaseAuth({
+      firebaseAppAuth: testAppAuth,
+      providers,
+    })(WrappedComponent);
+
+    const wrapped = mount(<EnhancedComponent />);
+
+    wrapped.find('button').simulate('click');
+
+    expect(testAppAuth.signInWithPopup).toHaveBeenCalledWith(
+      providers.facebookProvider
+    );
+  });
+
+  it('should call signInWithPopup with appleProvider instance when signInWithApple prop is invoked', () => {
+    const WrappedComponent = ({ signInWithApple }: WrappedComponentProps) => (
+      <button onClick={() => signInWithApple()}>signInWithApple</button>
     );
 
     const EnhancedComponent = withFirebaseAuth({


### PR DESCRIPTION
Adding option to include signup and login with Apple ID. Doesn't seem to be currently support, but there is the option to use it in the web version

https://firebase.google.com/docs/auth/web/apple

I believe for the example to work the firebase app in the config needs to be updated to include references from an Apple developer account.

```
yarn run v1.22.17
$ jest --coverage
 PASS  src/test.tsx
  withFirebaseAuth
    ✓ should be a function (2 ms)
    ✓ should render WrappedComponent (18 ms)
    ✓ should start with loading as false (24 ms)
    ✓ should setup onAuthStateChange listener when mounting the component (2 ms)
    ✓ should call onAuthStateChange unsubscriber when unmounting the component (3 ms)
    ✓ should update user in state when currentAuthStateObserver is invoked (2 ms)
    ✓ should call signInAnonymously when prop is invoked (6 ms)
    ✓ should call signOut when prop is invoked (2 ms)
    ✓ should call signInWithEmailAndPassword when prop is invoked (3 ms)
    ✓ should call signInWithPopup with googleProvider instance when signInWithGoogle prop is invoked (3 ms)
    ✓ should call signInWithPopup with twitterProvider instance when signInWithTwitter prop is invoked (3 ms)
    ✓ should call signInWithPopup with facebookProvider instance when signInWithFacebook prop is invoked (3 ms)
    ✓ should call signInWithPopup with appleProvider instance when signInWithApple prop is invoked (2 ms)
    ✓ should call signInWithPopup with githubProvider instance when signInWithGithub prop is invoked (2 ms)
    ✓ should call createUserWithEmailAndPassword when prop is invoked (5 ms)
    ✓ should call signInWithPhoneNumber when prop is invoked (2 ms)
    ✓ should set an error when setError is invoked (2 ms)
    ✓ should set an error when trying to call a login provider without providing its instance (2 ms)

-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |    90.91 |     100 |     100 |                   
 ...ForProvider.ts |     100 |      100 |     100 |     100 |                   
 index.tsx         |     100 |    90.91 |     100 |     100 | 77                
-------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        2.049 s, estimated 3 s
Ran all test suites.
Done in 2.97s.
````